### PR TITLE
[CI check] Removed '.*' import

### DIFF
--- a/app/src/main/java/homer/App.java
+++ b/app/src/main/java/homer/App.java
@@ -1,5 +1,5 @@
 package homer;
-
+/* Checkstyke warning should be suppressed */
 public final class App {
     public static void main(String[] args) {
     }

--- a/app/src/test/java/homer/AppTest.java
+++ b/app/src/test/java/homer/AppTest.java
@@ -4,7 +4,7 @@
 package homer;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class AppTest {
     @Test void appHasAGreeting() {


### PR DESCRIPTION
Partially fixed linter checkstyle errors, now we need to temporarily suppress the remaining one. 